### PR TITLE
ops(flux-home): retry auto-merge on transient github 5xx

### DIFF
--- a/.github/workflows/update-flux-home.yaml
+++ b/.github/workflows/update-flux-home.yaml
@@ -52,4 +52,15 @@ jobs:
       if: steps.create-pr.outputs.pull-request-operation == 'created' || steps.create-pr.outputs.pull-request-operation == 'updated'
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      run: gh pr merge --auto --rebase "${{ steps.create-pr.outputs.pull-request-url }}"
+        PR_URL: ${{ steps.create-pr.outputs.pull-request-url }}
+      run: |
+        for attempt in 1 2 3 4 5; do
+          if gh pr merge --auto --rebase "$PR_URL"; then
+            exit 0
+          fi
+          delay=$((attempt * 10))
+          echo "Attempt ${attempt} to enable auto-merge failed; retrying in ${delay}s"
+          sleep "${delay}"
+        done
+        echo "::error::Failed to enable auto-merge on ${PR_URL} after 5 attempts"
+        exit 1


### PR DESCRIPTION
Run [25482300320](https://github.com/buvis/clusters/actions/runs/25482300320) failed at the `Enable auto-merge` step with a 504 from GitHub's API. The PR (#4353) was created successfully and v2.8.6 already landed on master, so this was a transient API outage.

Wraps `gh pr merge --auto --rebase` in a 5-attempt retry loop with linear backoff (10/20/30/40/50s). `gh pr merge --auto` is idempotent (just sets the auto-merge flag), so retrying after a 5xx is safe.

Hoists `pull-request-url` into a `PR_URL` env var so it isn't re-templated on every retry line. Lints clean against the repo's yamllint config.